### PR TITLE
Fix `cloneTarStream` when passing `onEntry` option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -174,6 +174,7 @@ export async function cloneTarStream(
 					if (opts?.onEntry) {
 						try {
 							await opts.onEntry(pack, header, stream);
+							callback();
 						} catch (err) {
 							callback(err);
 						}


### PR DESCRIPTION
Change-type: patch